### PR TITLE
Update GitHub Actions to use IAM role for EKS authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ env:
   AWS_REGION: ap-south-1
   ECR_REPOSITORY: darpo-api
   EKS_CLUSTER: darpo-dev
+  ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_ARN }}
 
 jobs:
   deploy:
@@ -26,6 +27,8 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ env.AWS_REGION }}
+        role-to-assume: ${{ env.ROLE_TO_ASSUME }}
+        role-duration-seconds: 1200
 
     - name: Login to Amazon ECR
       id: login-ecr


### PR DESCRIPTION
## Description

This PR updates the GitHub Actions workflow to use IAM role assumption for EKS authentication.

### Changes:

1. **AWS Credentials Configuration**:
   ```yaml
   - name: Configure AWS credentials
     uses: aws-actions/configure-aws-credentials@v2
     with:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       aws-region: ${{ env.AWS_REGION }}
       role-to-assume: ${{ env.ROLE_TO_ASSUME }}
       role-duration-seconds: 1200
   ```

2. **Environment Variables**:
   - Added `ROLE_TO_ASSUME` environment variable
   - Uses `AWS_ROLE_ARN` secret

### Required Setup

After merging this PR, you need to:

1. Add new GitHub secret:
   - Name: `AWS_ROLE_ARN`
   - Value: Output from terraform `github_actions_role_arn`

2. Ensure IAM role exists in AWS (from darpo-infra changes)

## Testing

1. Verify workflow can:
   - Assume the role
   - Access EKS cluster
   - Create namespace and secrets
   - Deploy application

## Security Notes

- Role assumption is time-limited (1200 seconds)
- Uses least privilege principle
- Credentials are securely managed through GitHub secrets